### PR TITLE
Fix test

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -42,12 +42,12 @@ def webhook():
     		tmpl = Template('generic', elements=elements)
 
     		payload = tmpl
-    		msg = Message(m.sender, 'template', payload)
+    		msg = Message('template', payload)
     	else:
     		payload = m.text
-    		msg = Message(m.sender, 'text', payload)
+    		msg = Message('text', payload)
 
-    	response, error = bot.send_message(msg)
+    	response, error = bot.send_message(msg, m.sender)
 
     	if error:
     		return 'Bad Request'

--- a/fbmsgbot/bot.py
+++ b/fbmsgbot/bot.py
@@ -13,14 +13,21 @@ class Bot():
         self.api_token = token
         self.client = HttpClient(token)
 
-    def send_message(self, message):
+    def send_message(self, message, recipient):
 
-        message = json.dumps(message.to_json())
+        payload = {
+            'recipient': {
+                'id': recipient,
+            },
+            'message': message.to_json()
+        }
+
+        payload = json.dumps(payload)
 
         response, error = self.client.submit_request(
                             '/me/messages', 
                             'POST', 
-                            message)
+                            payload)
 
         if error is not None:
             print 'Error Encountered! Could not send message\n'

--- a/fbmsgbot/bot.py
+++ b/fbmsgbot/bot.py
@@ -15,10 +15,12 @@ class Bot():
 
     def send_message(self, message):
 
+        message = json.dumps(message.to_json())
+
         response, error = self.client.submit_request(
                             '/me/messages', 
                             'POST', 
-                            message.to_json())
+                            message)
 
         if error is not None:
             print 'Error Encountered! Could not send message\n'

--- a/fbmsgbot/models/message.py
+++ b/fbmsgbot/models/message.py
@@ -1,5 +1,3 @@
-import json
-
 supported_types = [
     'text',
     'image',
@@ -47,7 +45,7 @@ class Message():
             'message': data
         }
 
-        return json.dumps(message)
+        return message
     
 
 class ReceivedMessage(Message):

--- a/fbmsgbot/models/message.py
+++ b/fbmsgbot/models/message.py
@@ -12,11 +12,10 @@ class Message():
     Base message object
     """
 
-    def __init__(self, recipient, type, payload):
+    def __init__(self, type, payload):
 
         assert type in supported_types, 'That is not a supported type'
 
-        self.recipient = recipient
         self.type = type
         self.payload = payload
 
@@ -38,14 +37,7 @@ class Message():
                     'url': self.payload
                 }
 
-        message = {
-            'recipient': {
-                'id': self.recipient,
-            },
-            'message': data
-        }
-
-        return message
+        return data
     
 
 class ReceivedMessage(Message):

--- a/tests/models/test_attachment.py
+++ b/tests/models/test_attachment.py
@@ -24,13 +24,11 @@ class TestButton(unittest.TestCase):
         payload = PayloadButton("Button title2", "USR_DEFINE")
 
         webjson = weburl.to_json()
-        webjson = json.loads(webjson)
         assert webjson['type'] == "web_url", 'WebUrl type failed'
         assert webjson['title'] == "Button title", "WebUrl title failed"
         assert webjson['url'] == "www.test.com", "WebUrl URL failed"
 
         payloadjson = payload.to_json()
-        payloadjson = json.loads(payloadjson)
         assert payloadjson['type'] == "postback", "Payload type failed"
         assert payloadjson['title'] == "Button title2", "Button title failed"
         assert payloadjson['payload'] == "USR_DEFINE", "Button payload failed"
@@ -54,7 +52,7 @@ class TestElement(unittest.TestCase):
         button_list = [weburl, payload]
         element = Element("Grey Shirt", "www.greyshirt.com", "soft shirt", button_list)
         
-        element_json = json.loads(element.to_json())
+        element_json = element.to_json()
         assert element_json['title'] == "Grey Shirt"
         assert element_json['image_url'] == "www.greyshirt.com"
         assert element_json['subtitle'] == "soft shirt"

--- a/tests/models/test_message.py
+++ b/tests/models/test_message.py
@@ -12,15 +12,14 @@ class TestMessage(unittest.TestCase):
     """
 
     def test_message(self):
-        message = Message('123abc', 'image', 'google.com')
+        message = Message('image', 'google.com')
         assert message.type == 'image'
         assert message.payload == 'google.com'
-        assert message.recipient == '123abc'
 
     def test_text_message_to_json(self):
-        message = Message('123abc', 'image', 'google.com')
+        message = Message('image', 'google.com')
         json_ = message.to_json()
-        json_ = json.loads(json_)
+        print json_
         assert json_['attachment']['type'] == 'image'
         assert json_['attachment']['payload']['url'] == 'google.com'
 
@@ -38,11 +37,7 @@ class TestTemplate(unittest.TestCase):
                         title='title',
                   )
 
-        json_ = message.to_json()
-        json_ = json.loads(json_)
-        assert json_['message']['attachment']['type'] == 'template'
-
-        payload = json_['message']['attachment']['payload']
+        payload = message.to_json()
         assert payload['template_type'] == 'button'
         assert payload['text'] == 'title'
         assert payload['buttons'][0]['title'] =='title'
@@ -64,10 +59,6 @@ class TestTemplate(unittest.TestCase):
         message = Template(Template.generic_type,
                         elements=elements,)
 
-        json_ = message.to_json()
-        json_ = json.loads(json_)
-
-        assert json_['message']['attachment']['type'] == 'template'
-        payload = json_['message']['attachment']['payload']
+        payload = message.to_json()
         assert payload['template_type'] == 'generic'
         assert payload['elements'][0]['title'] =='t'

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -28,9 +28,9 @@ class TestBot(unittest.TestCase):
             }', status=201)
 
         bot = Bot("abc")
-        message = Message('123abc', 'image', 'google.com')          
+        message = Message('image', 'google.com')          
 
-        response, error = bot.send_message(message)
+        response, error = bot.send_message(message, '123abc')
         assert response['recipient_id'] == 1008
         assert response['message_id'] == "mid.1"
         assert error is None
@@ -56,7 +56,7 @@ class TestBot(unittest.TestCase):
                         title='Title',
                         buttons=buttons,)
 
-        bot.send_message(message)
+        bot.send_message(message, '123abc')
 
     @httpretty.activate
     def test_send_generic_structured_message(self):


### PR DESCRIPTION
I decided to pull out the recipient of the Message class to keep consistent with Facebook's API. The recipient is distinct from a message's content and this allows the reuse of messages if the same one should be sent to more than one person